### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	# Make sure to compile files after any other files they include!
 	$(PIP_COMPILE) --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	$(PIP_COMPILE) -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	$(PIP_COMPILE) -o requirements/base.txt requirements/base.in
 	$(PIP_COMPILE) -o requirements/test.txt requirements/test.in
 	$(PIP_COMPILE) -o requirements/ci.txt requirements/ci.in


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this [PR](https://github.com/openedx/edx-repo-health/pull/271) for new check added in edx-repo-health. 
JIRA: https://2u-internal.atlassian.net/browse/BOM-3430