### PR TITLE
docs: Update the contributing guidelines link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ How to Contribute
 Contributions are very welcome, but for legal reasons, you must submit a signed
 [individual contributor's agreement](http://code.edx.org/individual-contributor-agreement.pdf)
 before we can accept your contribution. See our
-[CONTRIBUTING](https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst)
+[CONTRIBUTING](https://github.com/openedx/.github/blob/master/CONTRIBUTING.md)
 file for more information -- it also contains guidelines for how to maintain
 high code quality, which will make your contribution more likely to be accepted.


### PR DESCRIPTION
We're moving towards a single set of guidelines org-wide.
