### PR TITLE
fix: remove pip constraint to fix make upgrade job

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,5 +12,5 @@ django==3.2.18
     #   -r requirements/base.in
 pytz==2023.3
     # via django
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,7 +6,7 @@
 #
 distlib==0.3.6
     # via virtualenv
-filelock==3.11.0
+filelock==3.12.0
     # via
     #   tox
     #   virtualenv
@@ -26,5 +26,5 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.in
-virtualenv==20.21.0
+virtualenv==20.22.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.3
+astroid==2.15.4
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -55,7 +55,7 @@ exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
-filelock==3.11.0
+filelock==3.12.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -118,7 +118,7 @@ py==1.11.0
     #   tox
 pycodestyle==2.10.0
     # via -r requirements/test.txt
-pylint==2.17.2
+pylint==2.17.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -169,7 +169,7 @@ six==1.16.0
     #   -r requirements/test.txt
     #   edx-lint
     #   tox
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/test.txt
     #   django
@@ -208,7 +208,7 @@ typing-extensions==4.5.0
     #   -r requirements/test.txt
     #   astroid
     #   pylint
-virtualenv==20.21.0
+virtualenv==20.22.0
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,6 +1,6 @@
 # Core dependencies for installing other packages
 -c constraints.txt
 
-pip<21.3  # pip==21.3 causes ImportError in pip-sync command when running make requirements
+pip
 setuptools
 wheel

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.2.4
+pip==23.1.1
     # via -r requirements/pip.in
-setuptools==67.6.1
+setuptools==67.7.2
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.15.3
+astroid==2.15.4
     # via
     #   pylint
     #   pylint-celery
@@ -58,7 +58,7 @@ pluggy==1.0.0
     # via pytest
 pycodestyle==2.10.0
     # via -r requirements/test.in
-pylint==2.17.2
+pylint==2.17.3
     # via
     #   edx-lint
     #   pylint-celery
@@ -90,7 +90,7 @@ pyyaml==6.0
     # via code-annotations
 six==1.16.0
     # via edx-lint
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/base.txt
     #   django


### PR DESCRIPTION
### Description
- Removed `pip` constraint to fix the failing `Python Requirements Upgrade` job.
- `pip-tools>=6.13.0` requires `pip>=23.1` so removing the constraint was necessary for fixing the failing job.